### PR TITLE
Support non-hbase-prefix configs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "pl.project13.scala"
 
 name := "akka-persistence-hbase"
 
-version := "0.3"
+version := "0.4-SNAPSHOT"
 
 scalaVersion := "2.10.2"
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -10,7 +10,8 @@ hbase-journal {
 
   # All these settings will be set on the underlying Hadoop Configuration
   hbase {
-    zookeeper.quorum = "localhost:2181"
+    hbase.zookeeper.quorum = "localhost:2181"
+    zookeeper.znode.parent = "/hbase"
   }
 
   # Name of the table to be created/used by the journal

--- a/src/main/scala/akka/persistence/hbase/journal/HBaseAsyncWriteJournal.scala
+++ b/src/main/scala/akka/persistence/hbase/journal/HBaseAsyncWriteJournal.scala
@@ -58,6 +58,7 @@ class HBaseAsyncWriteJournal extends Actor with ActorLogging
     flushWrites()
     Future.sequence(futures) map {
       case _ if publishTestingEvents => context.system.eventStream.publish(FinishedWrites(persistentBatch.size))
+      case _ =>
     }
   }
 

--- a/src/main/scala/akka/persistence/hbase/journal/HBaseClientFactory.scala
+++ b/src/main/scala/akka/persistence/hbase/journal/HBaseClientFactory.scala
@@ -11,7 +11,7 @@ object HBaseClientFactory {
 
   /** Always returns the same client */
   def getClient(config: PluginPersistenceSettings, persistenceSettings: PersistenceSettings): HBaseClient = {
-    client.compareAndSet(null, new HBaseClient(config.zookeeperQuorum))
+    client.compareAndSet(null, new HBaseClient(config.zookeeperQuorum, config.zookeeperParent))
 
     // since we will be forcing a flush anyway after each batch, let's not make asyncbase flush more than it needs to.
     // for example, we tell akka "200", but asyncbase was set to "20", so it would flush way more often than we'd expect it to.

--- a/src/main/scala/akka/persistence/hbase/journal/HBaseJournalInit.scala
+++ b/src/main/scala/akka/persistence/hbase/journal/HBaseJournalInit.scala
@@ -53,14 +53,13 @@ object HBaseJournalInit {
    */
   def getHBaseConfig(config: Config): Configuration = {
     val c = new Configuration()
-    @inline def hbaseKey(s: String) = "hbase." + s
 
     val journalConfig = config.getConfig("hbase-journal")
     val hbaseConfig = journalConfig.getConfig("hbase")
 
     // todo does not cover all cases
     hbaseConfig.entrySet().asScala foreach { e =>
-      c.set(hbaseKey(e.getKey), e.getValue.unwrapped.toString)
+      c.set(e.getKey, e.getValue.unwrapped.toString)
     }
     c
   }

--- a/src/main/scala/akka/persistence/hbase/journal/PluginPersistenceSettings.scala
+++ b/src/main/scala/akka/persistence/hbase/journal/PluginPersistenceSettings.scala
@@ -15,6 +15,7 @@ import org.apache.hadoop.conf.Configuration
  */
 case class PluginPersistenceSettings(
   zookeeperQuorum: String,
+  zookeeperParent: String,
   table: String,
   family: String,
   partitionCount: Int,
@@ -32,7 +33,8 @@ object PluginPersistenceSettings {
     val snapshotConfig = rootConfig.getConfig("hadoop-snapshot-store")
 
     PluginPersistenceSettings(
-      zookeeperQuorum      = journalConfig.getString("hbase.zookeeper.quorum"),
+      zookeeperQuorum      = journalConfig.getString("hbase.hbase.zookeeper.quorum"),
+      zookeeperParent      = journalConfig.getString("hbase.zookeeper.znode.parent"),
       table                = journalConfig.getString("table"),
       family               = journalConfig.getString("family"),
       partitionCount       = journalConfig.getInt("partition.count"),

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -23,8 +23,8 @@ hbase-journal {
   publish-testing-events = on
 
   hbase {
-    cluster.distributed = false
-    zookeeper.quorum = "localhost:2181"
+    hbase.cluster.distributed = false
+    hbase.zookeeper.quorum = "localhost:2181"
   }
 }
 

--- a/src/test/resources/local-hadoop.conf
+++ b/src/test/resources/local-hadoop.conf
@@ -20,8 +20,8 @@ hbase-journal {
   publish-testing-events = on
 
   hbase {
-    cluster.distributed = false
-    zookeeper.quorum = "localhost:2181"
+    hbase.cluster.distributed = false
+    hbase.zookeeper.quorum = "localhost:2181"
   }
 }
 


### PR DESCRIPTION
1. support hbase configs such as zookeeper.znode.parent
2. avoid scala matcher error in HBaseAsyncWriteJournal
