### PR TITLE
Fix bugs: make HBase stop key exclusive and send failure messages to persistent actors when message replay fails.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ val akkaVersion = "2.3.4"
 
 val hadoopVersion = "1.2.1"
 
-val hbaseVersion = "0.98.3-hadoop1"
+val hbaseVersion = "0.98.11-hadoop1"
 
 libraryDependencies += "org.apache.hadoop" % "hadoop-core"   % hadoopVersion
 

--- a/scripts/ci/after-script.sh
+++ b/scripts/ci/after-script.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
 
-sudo hbase-0.98.3-hadoop1/bin/stop-hbase.sh
+sudo hbase-0.98.11-hadoop1/bin/stop-hbase.sh

--- a/scripts/ci/before-script.sh
+++ b/scripts/ci/before-script.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
 
-sudo hbase-0.98.3-hadoop1/bin/start-hbase.sh
+sudo hbase-0.98.11-hadoop1/bin/start-hbase.sh

--- a/scripts/ci/install.sh
+++ b/scripts/ci/install.sh
@@ -1,4 +1,4 @@
 #! /bin/bash
 
-sudo wget http://www.eu.apache.org/dist/hbase/hbase-0.98.3/hbase-0.98.3-hadoop1-bin.tar.gz
-sudo tar xzf hbase-0.98.3-hadoop1-bin.tar.gz
+sudo wget http://apache.cs.utah.edu/hbase/hbase-0.98.11/hbase-0.98.11-hadoop1-bin.tar.gz
+sudo tar xzf hbase-0.98.11-hadoop1-bin.tar.gz

--- a/src/main/scala/akka/persistence/hbase/common/HBaseSerialization.scala
+++ b/src/main/scala/akka/persistence/hbase/common/HBaseSerialization.scala
@@ -13,7 +13,7 @@ trait HBaseSerialization {
     serialization.deserialize(bytes, classOf[Snapshot]).get
 
   protected def snapshotToBytes(msg: Snapshot): Array[Byte] =
-      serialization.serialize(msg).get
+    serialization.serialize(msg).get
 
   protected def persistentFromBytes(bytes: Array[Byte]): PersistentRepr =
     serialization.deserialize(bytes, classOf[PersistentRepr]).get

--- a/src/main/scala/akka/persistence/hbase/common/HBaseUtils.scala
+++ b/src/main/scala/akka/persistence/hbase/common/HBaseUtils.scala
@@ -38,9 +38,13 @@ trait HBaseUtils {
    * For snapshots
    */
   def preparePrefixScan(table: Array[Byte], family: Array[Byte], startScanKey: SnapshotRowKey, stopScanKey: SnapshotRowKey, persistenceIdPrefix: String, onlyRowKeys: Boolean): Scan = {
+    preparePrefixScan(table, family, startScanKey.toBytes, stopScanKey.toBytes, persistenceIdPrefix, onlyRowKeys)
+  }
+
+  def preparePrefixScan(table: Array[Byte], family: Array[Byte], startScanKey: Array[Byte], stopScanKey: Array[Byte], persistenceIdPrefix: String, onlyRowKeys: Boolean): Scan = {
     val scan = new Scan
-    scan.setStartRow(startScanKey.toBytes) // inclusive
-    scan.setStopRow(stopScanKey.toBytes) // exclusive
+    scan.setStartRow(startScanKey) // inclusive
+    scan.setStopRow(stopScanKey) // exclusive
     scan.setBatch(hBasePersistenceSettings.scanBatchSize)
 
     scan.setFilter(new PrefixFilter(Bytes.toBytes(persistenceIdPrefix)))

--- a/src/main/scala/akka/persistence/hbase/common/RowKey.scala
+++ b/src/main/scala/akka/persistence/hbase/common/RowKey.scala
@@ -49,6 +49,7 @@ object RowKey {
   def lastInPartition(persistenceId: String, partition: Long, toSequenceNr: Long = Long.MaxValue)(implicit journalConfig: PersistencePluginSettings) = {
     require(partition > 0, s"partition must be > 0, ($partition)")
     require(partition <= journalConfig.partitionCount, s"partition must be <= partitionCount, ($partition <!= ${journalConfig.partitionCount})")
+    require(toSequenceNr >= 0, s"toSequenceNr must be >= 0, ($toSequenceNr)")
 
     new RowKey(selectPartition(partition)(journalConfig), persistenceId, toSequenceNr)
   }

--- a/src/main/scala/akka/persistence/hbase/journal/HBaseAsyncWriteJournal.scala
+++ b/src/main/scala/akka/persistence/hbase/journal/HBaseAsyncWriteJournal.scala
@@ -84,8 +84,9 @@ class HBaseAsyncWriteJournal extends Actor with ActorLogging
     val doDelete = deleteFunctionFor(permanent)
 
     def scanAndDeletePartition(part: Long, operator: ActorRef): Unit = {
+      val stopSequenceNr = if (toSequenceNr < Long.MaxValue) toSequenceNr + 1 else Long.MaxValue
       val startScanKey = RowKey.firstInPartition(persistenceId, part)                 // 021-ID-000000000000000000
-      val stopScanKey = RowKey.lastInPartition(persistenceId, part, toSequenceNr + 1) // 021-ID-9223372036854775800
+      val stopScanKey = RowKey.lastInPartition(persistenceId, part, stopSequenceNr) // 021-ID-9223372036854775800
       val persistenceIdRowRegex = RowKey.patternForProcessor(persistenceId)           //  .*-ID-.*
 
       // we can avoid canning some partitions - guaranteed to be empty for smaller than the partition number seqNrs


### PR DESCRIPTION
HBase stop key is exclusive, which means little offset should be made to
stopKey when scanning Hbase tables.

Sending failure messages to persistent actors when message replay fails.
